### PR TITLE
#10 마이페이지 나머지 rcc hook 분리

### DIFF
--- a/src/components/pages/mypage/MyPageInfoWrapper.tsx
+++ b/src/components/pages/mypage/MyPageInfoWrapper.tsx
@@ -1,7 +1,5 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-
 import { Fragment, MouseEvent, useEffect, useState } from "react"
 import { useInView } from "react-intersection-observer"
 
@@ -15,6 +13,7 @@ import ReviewSkeleton from "@/components/public/Skeleton/ReviewSkeleton"
 import Spinner from "@/components/public/Spinner/Spinner"
 import LIMIT from "@/constants/limit"
 import ROUTE from "@/constants/route"
+import useNav from "@/hooks/useNav"
 import { IDataSort, IGetMyPageRes, IMyPageInfoWrapperProps, IReview } from "@/types/mypage/mypage"
 import { isCurrentDateAfter } from "@/util/days"
 import { useInfiniteQuery } from "@tanstack/react-query"
@@ -22,32 +21,10 @@ import { useInfiniteQuery } from "@tanstack/react-query"
 import MyPageDefault from "./MyPageDefault"
 import ReviewStateButton from "./ReviewStateButton"
 
-const useInfiniteQueryHook = (keyData: IDataSort) => {
-  const { data, isPending, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
-    queryKey: ["mypage", keyData],
-    queryFn: ({ queryKey, pageParam }) => {
-      const querySort = queryKey[1] as IDataSort
-      const fetchingKey = querySort.dataFetchingKey
-      const isReviewed = querySort.isReviewed ?? null
-      const offset = pageParam * LIMIT
-      const limit = LIMIT
-      return fetchMyPageInfo({ fetchingKey, offset, limit, isReviewed })
-    },
-    initialPageParam: 0,
-    getNextPageParam: (lastPage, _, lastPageParam) => {
-      return lastPage?.hasMore ? lastPageParam + 1 : undefined
-    },
-    staleTime: 1000,
-    gcTime: 1000,
-  })
-
-  return { data, isPending, fetchNextPage, isFetchingNextPage }
-}
-
 const MyPageInfoWrapper = ({ dataFetchingKey, onClick, isReviewed }: IMyPageInfoWrapperProps) => {
   const isMyOwnMeeting = dataFetchingKey === "myOwnMeeting"
   const isMyReview = dataFetchingKey === "myReview"
-  const router = useRouter()
+  const { goPath } = useNav()
   const [hasReview, setHasReview] = useState(isReviewed)
   const { ref, inView } = useInView({
     threshold: 1,
@@ -73,7 +50,7 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, isReviewed }: IMyPageInfo
 
   const clickCreateReviewHandler = (e: MouseEvent, pathId: number) => {
     e.preventDefault()
-    router.push(`${ROUTE.MY_PAGE}/addReview?gatheringId=${pathId}`)
+    goPath(`${ROUTE.MY_PAGE}/addReview?gatheringId=${pathId}`)
   }
 
   useEffect(() => {
@@ -199,3 +176,25 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, isReviewed }: IMyPageInfo
 }
 
 export default MyPageInfoWrapper
+
+const useInfiniteQueryHook = (keyData: IDataSort) => {
+  const { data, isPending, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ["mypage", keyData],
+    queryFn: ({ queryKey, pageParam }) => {
+      const querySort = queryKey[1] as IDataSort
+      const fetchingKey = querySort.dataFetchingKey
+      const isReviewed = querySort.isReviewed ?? null
+      const offset = pageParam * LIMIT
+      const limit = LIMIT
+      return fetchMyPageInfo({ fetchingKey, offset, limit, isReviewed })
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParam) => {
+      return lastPage?.hasMore ? lastPageParam + 1 : undefined
+    },
+    staleTime: 1000,
+    gcTime: 1000,
+  })
+
+  return { data, isPending, fetchNextPage, isFetchingNextPage }
+}

--- a/src/components/pages/mypage/MyPageInfoWrapper.tsx
+++ b/src/components/pages/mypage/MyPageInfoWrapper.tsx
@@ -61,6 +61,8 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, isReviewed }: IMyPageInfo
 
   const dataPages = data?.pages ?? []
 
+  const isDataEmpty = !isPending && dataPages[0]?.data.length === 0
+
   if (isPending) {
     if (dataFetchingKey === "myReview") {
       return <SkeletonWrapper component={<ReviewSkeleton />} />
@@ -68,7 +70,7 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, isReviewed }: IMyPageInfo
     return <SkeletonWrapper component={<CardSkeleton />} />
   }
 
-  if (!isPending && dataPages[0]?.data.length === 0) {
+  if (isDataEmpty) {
     return (
       <MyPageDefault
         dataFetchingKey={dataFetchingKey}

--- a/src/components/pages/mypage/MyPageInfoWrapper.tsx
+++ b/src/components/pages/mypage/MyPageInfoWrapper.tsx
@@ -55,6 +55,10 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, isReviewed }: IMyPageInfo
     goPath(`${ROUTE.MY_PAGE}/addReview?gatheringId=${pathId}`)
   }
 
+  const CardBtnHandler = (btnSort: boolean, pathId: number, e: MouseEvent) => {
+    return btnSort ? clickViewReviewHandler(e) : clickCreateReviewHandler(e, pathId)
+  }
+
   useEffect(() => {
     fetchNextPage()
   }, [inView, fetchNextPage])
@@ -127,13 +131,9 @@ const MyPageInfoWrapper = ({ dataFetchingKey, onClick, isReviewed }: IMyPageInfo
                       {isCurrentDateAfter(item.registrationEnd) ? (
                         <CardBtn
                           type="active"
-                          onClick={
-                            item.isReviewed
-                              ? clickViewReviewHandler
-                              : (e: MouseEvent) => {
-                                  clickCreateReviewHandler(e, item.id)
-                                }
-                          }
+                          onClick={(e: MouseEvent) => {
+                            return CardBtnHandler(item.isReviewed, item.id, e)
+                          }}
                         >
                           {item.isReviewed ? "내가 쓴 리뷰 보기" : "리뷰 작성하기"}
                         </CardBtn>

--- a/src/components/pages/mypage/SkeletonWrapper.tsx
+++ b/src/components/pages/mypage/SkeletonWrapper.tsx
@@ -1,0 +1,20 @@
+import { Fragment, ReactNode } from "react"
+
+import LIMIT from "@/constants/limit"
+
+const SkeletonWrapper = ({ component }: { component: ReactNode }) => {
+  return (
+    <div className="flex flex-col gap-4">
+      {new Array(LIMIT)
+        .fill(0)
+        .map((_, i) => {
+          return i + 1
+        })
+        .map((number) => {
+          return <Fragment key={number}>{component}</Fragment>
+        })}
+    </div>
+  )
+}
+
+export default SkeletonWrapper

--- a/src/components/public/ProfileEditBtn.tsx
+++ b/src/components/public/ProfileEditBtn.tsx
@@ -1,17 +1,18 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-
 import ROUTE from "@/constants/route"
+import useNav from "@/hooks/useNav"
 
 import Edit from "./img/Edit"
 
 const ProfileEditBtn = () => {
-  const handleClick = useNav()
+  const { goPath } = useNav()
 
   return (
     <button
-      onClick={handleClick}
+      onClick={() => {
+        return goPath(`${ROUTE.MY_PAGE}/edit`)
+      }}
       type="button"
       className="size-8 rounded-full border-none bg-cover bg-no-repeat"
     >
@@ -22,13 +23,3 @@ const ProfileEditBtn = () => {
 }
 
 export default ProfileEditBtn
-
-const useNav = () => {
-  const router = useRouter()
-
-  const handleClick = () => {
-    router.push(`${ROUTE.MY_PAGE}/edit`)
-  }
-
-  return handleClick
-}

--- a/src/hooks/useNav.ts
+++ b/src/hooks/useNav.ts
@@ -1,4 +1,4 @@
-import { useRouter } from "next/router"
+import { useRouter } from "next/navigation"
 
 const useNav = () => {
   const router = useRouter()

--- a/src/hooks/useNav.ts
+++ b/src/hooks/useNav.ts
@@ -1,0 +1,17 @@
+import { useRouter } from "next/router"
+
+const useNav = () => {
+  const router = useRouter()
+
+  const goPath = (path = "") => {
+    router.push(path)
+  }
+
+  const goBack = () => {
+    router.back()
+  }
+
+  return { goPath, goBack }
+}
+
+export default useNav


### PR DESCRIPTION
## #️⃣연관된 이슈

> #10 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- state 및 핸들러 분리
- 반복되는 컴포넌트 분리
- 조건문 통합
- useNav hook 생성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
 
- 나열되던 조건부 렌더링 부분 공통되는 부분 정리하고 삼항연산자로 합쳤습니다. 그런데 오히려 가독성을 헤치는 것 같습니다. 보시고 의견 부탁드립니다.
- useNav자체에서 원래 url을 받을 예정이었으나, router.back(), router.replace()등을 처리해야하기에 일단은 내부 함수들이 url을 받도록 만들었습니다. 어떤 부분에서 확장성이 있는지 확신이 안 서는데 확인 부탁드립니다.
- skeletonWrapper의 경우 처음에는 고차함수로 만들예정이었으나 컴포넌트 생성으로도 충분해 보여서 컴포넌트로 분리했습니다.
