### PR TITLE
#30 findmeeting page 컴포넌트 분리

### DIFF
--- a/src/app/allReview/page.tsx
+++ b/src/app/allReview/page.tsx
@@ -1,11 +1,10 @@
 import { Metadata } from "next"
-import Image from "next/image"
 
 import getQueryClient from "@/components/app/queryClient"
 import List from "@/components/pages/allReview/List"
 import Scores from "@/components/pages/allReview/Scores/Scores"
+import ImageHeader from "@/components/public/ImageHeader"
 import { allReviewOptions } from "@/hooks/Review/useAllReview"
-import HeadReviewIMG from "@public/img/head_review.png"
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query"
 
 export const metadata: Metadata = {
@@ -25,24 +24,8 @@ const AllReviewsPage = async () => {
   return (
     <main>
       <div className="m-6 flex min-h-screen flex-col rounded-[20px] bg-white px-6 py-14 md:m-12 md:px-16">
-        <div className="flex-none">
-          <div className="flex items-center gap-4 sm:gap-[13px]">
-            <div className="size-[72px] flex-none">
-              <Image width={72} height={72} src={HeadReviewIMG.src} alt="HeadReviewIMG" />
-            </div>
-            <div>
-              <h4 className="text-lg font-semibold leading-8 text-gray-900 sm:text-2xl">
-                모든 리뷰
-              </h4>
-              <p className="left-5 mt-2 text-sm font-medium text-gray-700">
-                같이달램을 이용한 분들은 이렇게 느꼈어요 🫶
-              </p>
-            </div>
-          </div>
-        </div>
-
+        <ImageHeader sort="review" mainText={mainText} subText={subText} />
         <Scores />
-
         <div className="flex flex-1 flex-col py-6">
           <HydrationBoundary state={dehydrate(queryClient)}>
             <List />
@@ -54,3 +37,6 @@ const AllReviewsPage = async () => {
 }
 
 export default AllReviewsPage
+
+const mainText = "모든 리뷰"
+const subText = "같이달램을 이용한 분들은 이렇게 느꼈어요 🫶"

--- a/src/app/findMeeting/page.tsx
+++ b/src/app/findMeeting/page.tsx
@@ -1,28 +1,24 @@
 "use client"
 
 import { useSession } from "next-auth/react"
-import Image from "next/image"
 
 import { useEffect, useState } from "react"
 import { useInView } from "react-intersection-observer"
 
-import FilterCalendar from "@/components/pages/findMeeting/FilterCalendar/FilterCalendar"
-import FilterSort from "@/components/pages/findMeeting/FilterSort/FilterSort"
+import CreateMeetingBtn from "@/components/pages/findMeeting/CreateMeetingBtn"
 import FilterTab from "@/components/pages/findMeeting/FilterTab/FilterTab"
+import FilterTabs from "@/components/pages/findMeeting/FilterTaps"
 import MeetingList from "@/components/pages/findMeeting/MeetingCard/MeetingList/MeetingList"
-import Filter from "@/components/public/Filter/Filter"
+import ImageHeader from "@/components/public/ImageHeader"
 import ResetFilter from "@/components/public/ResetFilter"
 import Spinner from "@/components/public/Spinner/Spinner"
-import Sort from "@/components/public/icon/dynamicIcon/Sort"
 import CreateMeetingModal from "@/components/public/modal/CreateMeetingModal"
 import LIMIT from "@/constants/limit"
-import { location } from "@/constants/meeting"
 import ROUTE from "@/constants/route"
 import useGetMeetingList from "@/hooks/useGetMeetingList"
 import useNav from "@/hooks/useNav"
 import { FetchFunction, IFilterOption } from "@/types/findMeeting/findMeeting"
 import onFilterChanged from "@/util/onFilterChanged"
-import headClassIMG from "@public/img/head_class.png"
 
 const FindMeetingPage = () => {
   const { isModalOpen, toggleModal, createMeetingHandler } = useMeeting()
@@ -40,87 +36,23 @@ const FindMeetingPage = () => {
 
   const { ref } = useNextPage(hasNextPage, fetchNextPage)
 
-  const isDesc = filterOption.sortOrder === "desc"
-
   const hasData = data && data.pages[0].length === 0
 
   return (
     <>
       <div className="m-6 flex min-h-screen flex-col rounded-[20px] bg-white px-6 py-14 md:m-12 md:px-16">
-        <div className="flex-none">
-          <div className="flex items-center gap-4">
-            <div className="size-[72px] flex-none">
-              <Image width={72} height={72} src={headClassIMG.src} alt="headClassIMG" />
-            </div>
-            <div>
-              <p className="text-sm font-medium text-gray-700">함께 할 사람이 없나요?</p>
-              <h4 className="mt-2 text-lg font-semibold leading-8 text-gray-900 sm:text-2xl">
-                지금 모임에 참여해보세요
-              </h4>
-            </div>
-          </div>
-        </div>
-        <div className="relative mt-12 flex justify-between">
+        <ImageHeader sort="meeting" mainText={mainText} subText={subText} />
+        <div className="relative mt-8 flex justify-between">
           <FilterTab
             selVal={filterOption.type}
             onSelect={(e) => {
               onFilterChanged(e, "type", filterOption, updateFilterOption)
             }}
           />
-          <button
-            type="button"
-            className="absolute right-0 top-0 h-[34px] w-[85px] rounded-lg border border-primary bg-primary text-xs font-semibold leading-6 text-white transition-colors hover:bg-white hover:text-primary sm:text-sm md:h-[44px] md:w-[115px] md:rounded-xl md:text-base"
-            onClick={createMeetingHandler}
-          >
-            모임 만들기
-          </button>
+          <CreateMeetingBtn onClick={createMeetingHandler} />
         </div>
-
-        <div className="mb-6 mt-4 flex flex-wrap items-center justify-between gap-4 border-t border-primary pt-4">
-          <div className="flex gap-2">
-            <Filter
-              data={location}
-              placeholder="지역 선택"
-              onSelect={(e) => {
-                onFilterChanged(e, "location", filterOption, updateFilterOption)
-              }}
-              selVal={filterOption.location}
-            />
-            <FilterCalendar
-              placeholder="날짜 선택"
-              selVal={filterOption.date}
-              onChange={(e) => {
-                onFilterChanged(e, "date", filterOption, updateFilterOption)
-              }}
-            />
-          </div>
-          <div className="ml-auto flex gap-2">
-            <button
-              aria-label="sortButton"
-              type="button"
-              className={`group flex size-9 cursor-pointer items-center justify-center rounded-xl border-2 transition-colors ${
-                isDesc ? "border-gray-100 bg-white" : "border-gray-100 bg-black"
-              }`}
-              onClick={() => {
-                const sortOrder = isDesc ? "asc" : "desc"
-                return updateFilterOption({ sortOrder })
-              }}
-            >
-              <Sort state="default" className={`transition-colors ${isDesc || "text-white"} `} />
-            </button>
-            <FilterSort
-              onSelect={(e) => {
-                onFilterChanged(e, "sortBy", filterOption, updateFilterOption)
-              }}
-              selVal={filterOption.sortBy}
-            />
-          </div>
-        </div>
-        {hasData && (
-          <p className="flex w-full flex-1 items-center justify-center text-sm text-gray-500">
-            첫 모임을 등록해주세요! 🖐️
-          </p>
-        )}
+        <FilterTabs filterOption={filterOption} updateFilterOption={updateFilterOption} />
+        {hasData && <DefaultValue />}
         <MeetingList data={data ?? null} isLoading={isLoading} />
         {isFetchingNextPage ? (
           <div className="py-7">
@@ -146,6 +78,9 @@ const FindMeetingPage = () => {
 }
 
 export default FindMeetingPage
+
+const mainText = "지금 모임에 참여해보세요"
+const subText = "함께 할 사람이 없나요?"
 
 const initialFilterOption: IFilterOption = {
   type: "DALLAEMFIT",
@@ -195,4 +130,12 @@ const hasChangedOption = (initialOption: IFilterOption, changedOption: IFilterOp
   const hasChangedOptions =
     getStringifiedOption(initialOption) !== getStringifiedOption(changedOption)
   return hasChangedOptions
+}
+
+const DefaultValue = () => {
+  return (
+    <p className="flex w-full flex-1 items-center justify-center text-sm text-gray-500">
+      첫 모임을 등록해주세요! 🖐️
+    </p>
+  )
 }

--- a/src/app/wishlist/page.tsx
+++ b/src/app/wishlist/page.tsx
@@ -1,27 +1,11 @@
-import Image from "next/image"
-
 import List from "@/components/pages/wishlist/List"
-import HeadSavedIMG from "@public/img/head_saved.png"
+import ImageHeader from "@/components/public/ImageHeader"
 
 const WishListPage = () => {
   return (
     <main>
       <div className="m-6 flex min-h-screen flex-col rounded-[20px] bg-white px-6 py-14 md:m-12 md:px-16">
-        <div className="flex-none">
-          <div className="flex items-center gap-4 sm:gap-[13px]">
-            <div className="size-[72px] flex-none">
-              <Image width={72} height={72} src={HeadSavedIMG.src} alt="HeadSavedIMG" />
-            </div>
-            <div>
-              <h4 className="text-lg font-semibold leading-8 text-gray-900 sm:text-2xl">
-                찜한 모임
-              </h4>
-              <p className="left-5 mt-2 text-sm font-medium text-gray-700">
-                마감되기 전에 지금 바로 참여해보세요 👀
-              </p>
-            </div>
-          </div>
-        </div>
+        <ImageHeader sort="wish" mainText={mainText} subText={subText} />
         <List />
       </div>
     </main>
@@ -29,3 +13,6 @@ const WishListPage = () => {
 }
 
 export default WishListPage
+
+const mainText = "찜한 모임"
+const subText = "마감되기 전에 지금 바로 참여해보세요 👀"

--- a/src/components/pages/findMeeting/CreateMeetingBtn.tsx
+++ b/src/components/pages/findMeeting/CreateMeetingBtn.tsx
@@ -1,0 +1,15 @@
+import { DefaultHandlerProp } from "@/types/findMeeting/findMeeting"
+
+const CreateMeetingBtn = ({ onClick }: DefaultHandlerProp) => {
+  return (
+    <button
+      type="button"
+      className="absolute right-0 top-0 h-[34px] w-[85px] rounded-lg border border-primary bg-primary text-xs font-semibold leading-6 text-white transition-colors hover:bg-white hover:text-primary sm:text-sm md:h-[44px] md:w-[115px] md:rounded-xl md:text-base"
+      onClick={onClick}
+    >
+      모임 만들기
+    </button>
+  )
+}
+
+export default CreateMeetingBtn

--- a/src/components/pages/findMeeting/FilterTaps.tsx
+++ b/src/components/pages/findMeeting/FilterTaps.tsx
@@ -1,0 +1,61 @@
+import FilterSort from "@/components/pages/findMeeting/FilterSort/FilterSort"
+import Filter from "@/components/public/Filter/Filter"
+import Sort from "@/components/public/icon/dynamicIcon/Sort"
+import { location } from "@/constants/meeting"
+import { IFilterOption } from "@/types/findMeeting/findMeeting"
+import onFilterChanged from "@/util/onFilterChanged"
+
+import FilterCalendar from "./FilterCalendar/FilterCalendar"
+
+interface FilterTabProp {
+  filterOption: IFilterOption
+  updateFilterOption: (newOption: Partial<IFilterOption>) => void
+}
+
+const FilterTabs = ({ filterOption, updateFilterOption }: FilterTabProp) => {
+  const isDesc = filterOption.sortOrder === "desc"
+  return (
+    <div className="mb-6 mt-4 flex flex-wrap items-center justify-between gap-4 border-t border-primary pt-4">
+      <div className="flex gap-2">
+        <Filter
+          data={location}
+          placeholder="지역 선택"
+          onSelect={(e) => {
+            onFilterChanged(e, "location", filterOption, updateFilterOption)
+          }}
+          selVal={filterOption.location}
+        />
+        <FilterCalendar
+          placeholder="날짜 선택"
+          selVal={filterOption.date}
+          onChange={(e) => {
+            onFilterChanged(e, "date", filterOption, updateFilterOption)
+          }}
+        />
+      </div>
+      <div className="ml-auto flex gap-2">
+        <button
+          aria-label="sortButton"
+          type="button"
+          className={`group flex size-9 cursor-pointer items-center justify-center rounded-xl border-2 transition-colors ${
+            isDesc ? "border-gray-100 bg-white" : "border-gray-100 bg-black"
+          }`}
+          onClick={() => {
+            const sortOrder = isDesc ? "asc" : "desc"
+            return updateFilterOption({ sortOrder })
+          }}
+        >
+          <Sort state="default" className={`transition-colors ${isDesc || "text-white"} `} />
+        </button>
+        <FilterSort
+          onSelect={(e) => {
+            onFilterChanged(e, "sortBy", filterOption, updateFilterOption)
+          }}
+          selVal={filterOption.sortBy}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default FilterTabs

--- a/src/components/public/ImageHeader.tsx
+++ b/src/components/public/ImageHeader.tsx
@@ -1,0 +1,40 @@
+import Image from "next/image"
+
+import { ImageHeaderProp } from "@/types/common/global"
+import headClassIMG from "@public/img/head_class.png"
+import headReviewIMG from "@public/img/head_review.png"
+import headWishIMG from "@public/img/head_saved.png"
+
+const ImageHeader = ({ sort, mainText, subText }: ImageHeaderProp) => {
+  const imageSrc = getImageSrc(sort)
+  const isMeeting = sort === "meeting"
+  return (
+    <div className="flex-none">
+      <div className="flex items-center gap-4">
+        <div className="size-[72px] flex-none">
+          <Image width={72} height={72} src={imageSrc} alt="headClassIMG" />
+        </div>
+        <div>
+          {isMeeting && <p className="text-sm font-medium text-gray-700">{subText}</p>}
+          <h4 className="mt-2 text-lg font-semibold leading-8 text-gray-900 sm:text-2xl">
+            {mainText}
+          </h4>
+          {!isMeeting && <p className="left-5 mt-2 text-sm font-medium text-gray-700">{subText}</p>}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ImageHeader
+
+const getImageSrc = (sort: string): string => {
+  switch (sort) {
+    case "meeting":
+      return headClassIMG.src
+    case "wish":
+      return headWishIMG.src
+    default:
+      return headReviewIMG.src
+  }
+}

--- a/src/types/common/global.d.ts
+++ b/src/types/common/global.d.ts
@@ -7,3 +7,9 @@ declare module "*.svg" {
   // import { ReactComponent as SVGName } from '/src/SVGName.svg'의 형태로 불러올 때 사용됩니다.
   export const ReactComponent: React.VFC<React.SVGProps<SVGSVGElement>>
 }
+
+export type ImageHeaderProp = {
+  sort: "wish" | "meeting" | "review"
+  mainText: string
+  subText: string
+}

--- a/src/types/findMeeting/findMeeting.d.ts
+++ b/src/types/findMeeting/findMeeting.d.ts
@@ -10,6 +10,10 @@ export type FetchFunction = (
   options?: FetchNextPageOptions,
 ) => Promise<InfiniteQueryObserverResult<InfiniteData<IMeetingData[], unknown>, Error>>
 
+export interface DefaultHandlerProp {
+  [key: string]: () => void
+}
+
 export type TCustomFilterEvent =
   | MouseEvent<HTMLButtonElement>
   | KeyboardEvent<HTMLButtonElement>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #30 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)


<img src="https://github.com/user-attachments/assets/c88efdd8-34dc-481b-b26c-db7a4163b797" width="340" />
<br />
<img src="https://github.com/user-attachments/assets/8f0b711b-a44f-4629-a314-be5823bdba17" width="300" />
<br />
<img src="https://github.com/user-attachments/assets/b459167b-af0a-4cf6-b41b-4a60c7d7030b" width="300" />

- 각 페이지별 같은 역할하는 태그 발견
- 공통 컴포넌트 생성 및 통합

![test](https://github.com/user-attachments/assets/c67ab572-4722-45fc-8727-71a5f2d30618)


- 나머지 나열된 태그들 역할별로 분리 및 컴포넌트화

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
