### PR TITLE
13 toast 방식 수정

### DIFF
--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -1,19 +1,18 @@
 "use client"
 
-import { useRouter } from "next/navigation"
-
 import { useEffect } from "react"
 
+import useNav from "@/hooks/useNav"
 import { useToast } from "@/provider/ToastProvider"
 
 const CallbackPage = () => {
   const { openToast } = useToast()
-  const router = useRouter()
+  const { goPath } = useNav()
 
   useEffect(() => {
     openToast("로그인 이후에 이용이 가능힙니다.", "error")
-    router.push("/")
-  }, [openToast, router])
+    goPath("/")
+  }, [openToast, goPath])
 
   return null
 }

--- a/src/app/callback/page.tsx
+++ b/src/app/callback/page.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+
+import { useEffect } from "react"
+
+import { useToast } from "@/provider/ToastProvider"
+
+const CallbackPage = () => {
+  const { openToast } = useToast()
+  const router = useRouter()
+
+  useEffect(() => {
+    openToast("로그인 이후에 이용이 가능힙니다.", "error")
+    router.push("/")
+  }, [openToast, router])
+
+  return null
+}
+
+export default CallbackPage

--- a/src/app/findMeeting/page.tsx
+++ b/src/app/findMeeting/page.tsx
@@ -14,9 +14,8 @@ import ResetFilter from "@/components/public/ResetFilter"
 import Spinner from "@/components/public/Spinner/Spinner"
 import CreateMeetingModal from "@/components/public/modal/CreateMeetingModal"
 import LIMIT from "@/constants/limit"
-import ROUTE from "@/constants/route"
 import useGetMeetingList from "@/hooks/useGetMeetingList"
-import useNav from "@/hooks/useNav"
+import { useToast } from "@/provider/ToastProvider"
 import { FetchFunction, IFilterOption } from "@/types/findMeeting/findMeeting"
 import onFilterChanged from "@/util/onFilterChanged"
 
@@ -90,8 +89,8 @@ const initialFilterOption: IFilterOption = {
 }
 
 const useMeeting = () => {
+  const { openToast } = useToast()
   const session = useSession()
-  const { goPath } = useNav()
 
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -103,7 +102,7 @@ const useMeeting = () => {
     if (session.data) {
       toggleModal()
     } else {
-      goPath(`${ROUTE.SIGNIN}&alert=로그인 후 이용이 가능합니다.`)
+      openToast("로그인 후 이용이 가능합니다.", "success")
     }
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import localFont from "next/font/local"
 import QueryProviders from "@/components/app/provider"
 import GNB from "@/components/public/gnb/GNB"
 import { CountProvider } from "@/provider/CountProvider"
+import { ToastProvider } from "@/provider/ToastProvider"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 import "./globals.css"
@@ -69,12 +70,14 @@ const RootLayout = ({
     <html lang="ko" className={`${pretendard.className} ${tmoneyRoundWind.variable}`}>
       <body className="bg-gray-100">
         <SessionProvider>
-          <CountProvider>
-            <QueryProviders>
-              <GNB>{children}</GNB>
-              {process.env.NODE_ENV !== "production" && <ReactQueryDevtools position="bottom" />}
-            </QueryProviders>
-          </CountProvider>
+          <ToastProvider>
+            <CountProvider>
+              <QueryProviders>
+                <GNB>{children}</GNB>
+                {process.env.NODE_ENV !== "production" && <ReactQueryDevtools position="bottom" />}
+              </QueryProviders>
+            </CountProvider>
+          </ToastProvider>
         </SessionProvider>
       </body>
     </html>

--- a/src/components/pages/auth/Modal/LoginModal.tsx
+++ b/src/components/pages/auth/Modal/LoginModal.tsx
@@ -2,6 +2,7 @@
 
 import { signIn } from "next-auth/react"
 import Image from "next/image"
+import { useRouter } from "next/navigation"
 
 import { Dispatch, SetStateAction, useState } from "react"
 import { useForm } from "react-hook-form"
@@ -81,11 +82,14 @@ const useSubmit = () => {
   } = useForm()
 
   const [error, setError] = useState("")
+  const router = useRouter()
 
   const onSubmit = handleSubmit(async (data) => {
-    const res = await signIn("credentials", { ...data, redirect: false, callbackUrl: "/" })
+    const res = await signIn("credentials", { ...data, redirect: false })
     if (res?.error) {
       setError("잘못된 이메일 또는 비밀번호입니다")
+    } else {
+      router.refresh()
     }
   })
 

--- a/src/components/pages/findMeeting/MeetingCard/MeetingList/MeetingList.tsx
+++ b/src/components/pages/findMeeting/MeetingCard/MeetingList/MeetingList.tsx
@@ -1,7 +1,6 @@
 import { useSession } from "next-auth/react"
 import Image from "next/image"
 import Link from "next/link"
-import { usePathname, useRouter } from "next/navigation"
 
 import { MouseEvent } from "react"
 
@@ -10,6 +9,7 @@ import DateTag from "@/components/pages/findMeeting/MeetingCard/Atoms/DateTag"
 import ParticipantGage from "@/components/pages/findMeeting/MeetingCard/Atoms/ParticipantGage"
 import WishBtn from "@/components/pages/wishlist/WishBtn"
 import Spinner from "@/components/public/Spinner/Spinner"
+import { useToast } from "@/provider/ToastProvider"
 import { IMeetingData, IMeetingListProps } from "@/types/findMeeting/findMeeting"
 import { isCurrentDateAfter, msTransform } from "@/util/days"
 import ArrowRightSVG from "@public/icon/staticIcon/arrow_right.svg"
@@ -17,11 +17,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import dayjs from "dayjs"
 
 export const MeetingCard = ({ data }: { data: IMeetingData }) => {
+  const { openToast } = useToast()
   const session = useSession()
 
-  const router = useRouter()
   const queryClient = useQueryClient()
-  const pathname = usePathname()
 
   const mutation = useMutation({
     mutationFn: () => {
@@ -37,9 +36,9 @@ export const MeetingCard = ({ data }: { data: IMeetingData }) => {
 
     if (session.data) {
       const res = await mutation.mutateAsync()
-      router.replace(`${pathname}?alert=${res}&type=alert`, { scroll: false })
+      openToast(res, "success")
     } else {
-      router.replace(`${pathname}?alert=${"로그인이 필요합니다."}`, { scroll: false })
+      openToast("로그인이 필요합니다.", "error")
     }
   }
 

--- a/src/components/pages/wishlist/WishBtn.tsx
+++ b/src/components/pages/wishlist/WishBtn.tsx
@@ -1,12 +1,11 @@
 "use client"
 
 import { useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
 
 import { MouseEvent, useEffect, useState } from "react"
 
-import ROUTE from "@/constants/route"
 import { useWishCount } from "@/provider/CountProvider"
+import { useToast } from "@/provider/ToastProvider"
 import { IWishListData } from "@/types/wishlist/wishlist"
 import Heart from "@public/icon/dynamicIcon/heart.svg"
 
@@ -15,8 +14,8 @@ import Heart from "@public/icon/dynamicIcon/heart.svg"
  */
 
 const WishBtn = ({ list }: { list: IWishListData }) => {
+  const { openToast } = useToast()
   const session = useSession()
-  const router = useRouter()
   const [isWish, setIsWish] = useState(false)
   const { setWishCount } = useWishCount()
 
@@ -50,7 +49,7 @@ const WishBtn = ({ list }: { list: IWishListData }) => {
 
       setIsWish(!isWish)
     } else {
-      router.replace(`${ROUTE.GATHERINGS}?alert=${"로그인이 필요합니다."}`)
+      openToast("로그인이 필요합니다.", "error")
     }
   }
 

--- a/src/components/public/Toast.tsx
+++ b/src/components/public/Toast.tsx
@@ -54,13 +54,17 @@ const useToastTransition = ({
 
   const handleClose = useCallback(() => {
     setIsVisible(false)
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       closeToast()
     }, DURATION)
+
+    return () => {
+      clearTimeout(timer)
+    }
   }, [closeToast])
 
   useEffect(() => {
-    let timer: any
+    let timer: ReturnType<typeof setTimeout> | null = null
     if (isVisible) {
       timer = setTimeout(handleClose, 3000) // 3초 후 자동으로 닫힘
     }

--- a/src/components/public/Toast.tsx
+++ b/src/components/public/Toast.tsx
@@ -1,65 +1,29 @@
 "use client"
 
-import { usePathname, useRouter, useSearchParams } from "next/navigation"
-
-import { useCallback, useEffect, useState } from "react"
+import { useState } from "react"
 import { IoAlertOutline, IoCheckmark } from "react-icons/io5"
 
 import { animated, useTransition } from "@react-spring/web"
 
-const Toast = () => {
-  const router = useRouter()
-  const searchParams = useSearchParams()
-  const [message, setMessage] = useState("")
-  const pathname = usePathname()
-  const search = searchParams.get("alert")
-  const type = searchParams.get("type") || "error"
-
-  const newURL = useCallback(() => {
-    const newParams = new URLSearchParams(searchParams.toString())
-    newParams.delete("type")
-    newParams.delete("alert")
-    const url = `${pathname}?${newParams.toString()}`
-    return url
-  }, [pathname, searchParams])
-
-  useEffect(() => {
-    if (!search) return
-    setMessage(search)
-  }, [search, router, newURL])
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      router.replace(newURL(), { scroll: false })
-      setMessage("")
-    }, 3000)
-    return () => {
-      clearTimeout(timer)
-    }
-  }, [message, router, newURL])
-
-  const transitions = useTransition(message, {
-    from: { opacity: 0, x: "100%" },
-    enter: { opacity: 1, x: "0%" },
-    leave: { opacity: 0, x: "100%" },
-    config: {
-      duration: 300,
-      tension: 120,
-      friction: 44,
-    },
-    delay: message ? 100 : 0,
-  })
+const Toast = ({
+  toast,
+  closeToast,
+}: {
+  toast: { message: string; type: string }
+  closeToast: () => void
+}) => {
+  const { transitions, message } = useToastTransition({ closeToast, toastMsg: toast.message })
 
   return transitions((style, item) => {
     return item ? (
       <animated.div
         style={style}
-        className={`fixed right-4 top-[90px] z-50 inline-flex items-center gap-2 rounded-full px-4 py-2 shadow-lg ${type === "error" ? "bg-red-100" : "bg-green-100"}`}
+        className={`fixed right-4 top-[90px] z-50 inline-flex items-center gap-2 rounded-full px-4 py-2 shadow-lg ${toast.type === "error" ? "bg-red-100" : "bg-green-100"}`}
       >
         <div
-          className={`flex size-4 items-center justify-center rounded-full text-[10px] text-white md:size-5 ${type === "error" ? "bg-red-400" : "bg-green-400"}`}
+          className={`flex size-4 items-center justify-center rounded-full text-[10px] text-white md:size-5 ${toast.type === "error" ? "bg-red-400" : "bg-green-400"}`}
         >
-          {type === "error" ? <IoAlertOutline /> : <IoCheckmark />}
+          {toast.type === "error" ? <IoAlertOutline /> : <IoCheckmark />}
         </div>
         <p className="text-[10px] text-gray-700 md:text-xs">{message}</p>
       </animated.div>
@@ -68,3 +32,35 @@ const Toast = () => {
 }
 
 export default Toast
+
+const useToastTransition = ({
+  closeToast,
+  toastMsg,
+}: {
+  closeToast: () => void
+  toastMsg: string
+}) => {
+  const [message, setMessage] = useState("")
+
+  const transitions = useTransition(toastMsg, {
+    from: { opacity: 0, x: "100%" },
+    enter: { opacity: 1, x: "0%" },
+    leave: { opacity: 0, x: "100%" },
+    config: {
+      duration: 300,
+      tension: 120,
+      friction: 44,
+    },
+    delay: toastMsg ? 100 : 3000,
+    onStart: () => {
+      if (toastMsg) {
+        setMessage(toastMsg)
+      }
+    },
+    onRest: () => {
+      closeToast()
+    },
+  })
+
+  return { transitions, message }
+}

--- a/src/components/public/bottomFloatingBar/BottomFloatingBar.tsx
+++ b/src/components/public/bottomFloatingBar/BottomFloatingBar.tsx
@@ -9,11 +9,13 @@ import cancelMeeting from "@/actions/Gatherings/cancelMeeting"
 import quitMeeting from "@/actions/Gatherings/quitMeeting"
 import ROUTE from "@/constants/route"
 import useJoinGathering from "@/hooks/Gatherings/useJoinGathering"
+import { useToast } from "@/provider/ToastProvider"
 import { IBannerProps } from "@/types/findMeeting/findMeeting"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 
 const BottomBanner = ({ id, isHost, isJoined, limit, participant, setHeight }: IBannerProps) => {
   const ref = useRef<HTMLDivElement>(null)
+  const { openToast } = useToast()
   const session = useSession()
 
   const queryClient = useQueryClient()
@@ -33,7 +35,7 @@ const BottomBanner = ({ id, isHost, isJoined, limit, participant, setHeight }: I
         queryKey: ["mypage"],
       })
 
-      router.replace(`${ROUTE.GATHERINGS}/${id}?alert=${res}`)
+      openToast(res, "success")
     },
   })
 
@@ -47,8 +49,9 @@ const BottomBanner = ({ id, isHost, isJoined, limit, participant, setHeight }: I
         queryKey: ["mypage"],
       })
 
-      if (res) router.replace(`${ROUTE.GATHERINGS}?alert=${res}`)
-      else router.replace(ROUTE.GATHERINGS)
+      if (res) {
+        openToast(res, "success")
+      } else router.replace(ROUTE.GATHERINGS)
     },
   })
 
@@ -79,12 +82,11 @@ const BottomBanner = ({ id, isHost, isJoined, limit, participant, setHeight }: I
           await queryClient.invalidateQueries({
             queryKey: ["mypage"],
           })
-
-          router.replace(`${ROUTE.GATHERINGS}/${id}?alert=${res}`)
+          openToast(res, "success")
         },
       })
     } else {
-      router.replace(`${ROUTE.GATHERINGS}/${id}?alert=${"로그인이 필요합니다."}`)
+      openToast("로그인이 필요합니다.", "error")
     }
   }
 
@@ -94,9 +96,7 @@ const BottomBanner = ({ id, isHost, isJoined, limit, participant, setHeight }: I
 
   const onClickShare = () => {
     navigator.clipboard.writeText(window.location.href)
-    router.replace(`${ROUTE.GATHERINGS}/${id}?alert=클립보드에 복사됐습니다.&type=alert`, {
-      scroll: false,
-    })
+    openToast("클립보드에 복사됐습니다", "success")
   }
 
   useEffect(() => {

--- a/src/components/public/gnb/Profile/Atoms/Authenticated.tsx
+++ b/src/components/public/gnb/Profile/Atoms/Authenticated.tsx
@@ -55,7 +55,7 @@ const Authenticated = ({ token }: { token: string }) => {
             <button
               type="button"
               onClick={() => {
-                signOut()
+                signOut({ callbackUrl: "/" })
               }}
               className="h-full w-full"
             >

--- a/src/hooks/useNav.ts
+++ b/src/hooks/useNav.ts
@@ -3,7 +3,7 @@ import { useRouter } from "next/navigation"
 const useNav = () => {
   const router = useRouter()
 
-  const goPath = (path = "") => {
+  const goPath = (path = "/") => {
     router.push(path)
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,21 +1,15 @@
-import { NextAuthRequest } from "next-auth/lib"
+import { NextResponse } from "next/server"
 
 import { auth } from "@/auth"
 
-import ROUTE from "./constants/route"
-
-const isAuth = (req: NextAuthRequest, url: string) => {
-  return !req.auth && req.nextUrl.pathname === url
-}
-
 // eslint-disable-next-line consistent-return
 export default auth((req) => {
-  if (isAuth(req, "/mypage") || isAuth(req, "/wishlist")) {
-    const newUrl = new URL(ROUTE.HOME, req.nextUrl.origin)
-    return Response.redirect(newUrl)
+  if (!req.auth) {
+    return NextResponse.redirect(new URL("/callback", req.url))
   }
+  return NextResponse.next()
 })
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/mypage", "/wishlist"],
 }

--- a/src/provider/ToastProvider.tsx
+++ b/src/provider/ToastProvider.tsx
@@ -9,8 +9,6 @@ interface IToastCountContext {
   closeToast: () => void
 }
 
-const ToastCountContext = createContext<IToastCountContext | null>(null)
-
 export const ToastProvider = ({ children }: { children: ReactNode }) => {
   const [toast, setToast] = useState({ message: "", type: "active" })
 
@@ -41,6 +39,8 @@ export const ToastProvider = ({ children }: { children: ReactNode }) => {
     </ToastCountContext.Provider>
   )
 }
+
+const ToastCountContext = createContext<IToastCountContext | null>(null)
 
 export const useToast = () => {
   const { openToast, closeToast } = useContext(ToastCountContext) as IToastCountContext

--- a/src/provider/ToastProvider.tsx
+++ b/src/provider/ToastProvider.tsx
@@ -1,14 +1,48 @@
-import { ReactNode } from "react"
+"use client"
+
+import { ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react"
 
 import Toast from "@/components/public/Toast"
 
-const ToastProvider = ({ children }: { children: ReactNode }) => {
+interface IToastCountContext {
+  openToast: (message: string, type: "error" | "success") => void
+  closeToast: () => void
+}
+
+const ToastCountContext = createContext<IToastCountContext | null>(null)
+
+export const ToastProvider = ({ children }: { children: ReactNode }) => {
+  const [toast, setToast] = useState({ message: "", type: "active" })
+
+  const openToast = useCallback((message: string, type: "error" | "success") => {
+    setToast((prev) => {
+      return {
+        ...prev,
+        message,
+        type,
+      }
+    })
+  }, [])
+
+  const closeToast = useCallback(() => {
+    setToast((prev) => {
+      return { ...prev, message: "" }
+    })
+  }, [])
+
+  const value = useMemo(() => {
+    return { openToast, closeToast }
+  }, [openToast, closeToast])
+
   return (
-    <>
+    <ToastCountContext.Provider value={value}>
       {children}
-      <Toast />
-    </>
+      <Toast toast={toast} closeToast={closeToast} />
+    </ToastCountContext.Provider>
   )
 }
 
-export default ToastProvider
+export const useToast = () => {
+  const { openToast, closeToast } = useContext(ToastCountContext) as IToastCountContext
+  return { openToast, closeToast }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13 

## 📝작업 내용

> TOAST 애니메이션 방식을 수정 하고 replace 형식을 모두 수정 했습니다.

> 또한 이미 접속한 기록이 있는곳은 middleware가 검사를 하지 않아 로그인 뒤에도 접속이 불가능한 버그가 있었습니다.
> 로그인했을경우 router를 이용해서 refersh를 해주는 방안을 선택했습니다.
> 또한 로그인이 안되어있을 경우 접속되면 안되는 페이지 또한 middleware를 걸쳐서 callback Page로 넘어가서 toast를 실행시켜준뒤 router를 이용해서 메인화면으로 이동하게 했습니다.

## 💬리뷰 요구사항(선택)

Toast 실행되고 있을 경우 다시 실행되면 Toast가 꺼지지 않는 버그를 해결하는데 고생했습니다..
문제는 애니메이션이 끝났을 때 바로 받아주게 끔 한 게 문제였는데
애니메이션이 여러번 실행 되다보니 애니메이션이 끝나지 않아서 생긴 오류 같습니다.

해결방안
```
isVisible라는 state를 만들어서
const handleClose = useCallback(() => {
    setIsVisible(false)
    setTimeout(() => {
      closeToast()
    }, DURATION)
  }, [closeToast])

  useEffect(() => {
    let timer: any
    if (isVisible) {
      timer = setTimeout(handleClose, 3000) // 3초 후 자동으로 닫힘
    }
    return () => {
      if (timer) {
        clearTimeout(timer)
      }
    }
  }, [isVisible, handleClose])
```

해당 방식으로 수정 했습니다.


