### PR TITLE
#34 hydrationboundary custom hook으로 분리

### DIFF
--- a/src/app/(MyPage)/mypage/page.tsx
+++ b/src/app/(MyPage)/mypage/page.tsx
@@ -1,18 +1,15 @@
 import MyPageInfoTap from "@/components/pages/mypage/MyPageInfoTap"
 import ProfileBox from "@/components/public/ProfileBox"
+import CustomHydrationBoundary from "@/hooks/CustomHydrationBoundary.tsx"
 import MyPagePrefetchOption from "@/hooks/mypage/myPageQuery"
-import { HydrationBoundary, QueryClient, dehydrate } from "@tanstack/react-query"
 
-const MyPage = async () => {
-  const queryClient = new QueryClient()
-  await queryClient.prefetchQuery(MyPagePrefetchOption())
-
+const MyPage = () => {
   return (
     <div className="flex h-full flex-col items-stretch gap-3">
       <ProfileBox />
-      <HydrationBoundary state={dehydrate(queryClient)}>
+      <CustomHydrationBoundary options={MyPagePrefetchOption()}>
         <MyPageInfoTap />
-      </HydrationBoundary>
+      </CustomHydrationBoundary>
     </div>
   )
 }

--- a/src/hooks/CustomHydrationBoundary.tsx.tsx
+++ b/src/hooks/CustomHydrationBoundary.tsx.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react"
+
+import getQueryClient from "@/components/app/queryClient"
+import { DataTag, HydrationBoundary, UseQueryOptions, dehydrate } from "@tanstack/react-query"
+
+type UseQueryOptionsCompatible = UseQueryOptions<
+  { data: any; hasMore: boolean },
+  Error,
+  { data: any; hasMore: boolean },
+  {}[]
+> & { initialData?: undefined } & { queryKey: DataTag<{}[], { data: any; hasMore: boolean }> }
+
+interface CustomHydrationBoundaryProp {
+  children: ReactNode
+  options: UseQueryOptionsCompatible
+}
+
+const CustomHydrationBoundary = ({ options, children }: CustomHydrationBoundaryProp) => {
+  const queryClient = getQueryClient()
+  queryClient.prefetchQuery(options)
+
+  return <HydrationBoundary state={dehydrate(queryClient)}>{children}</HydrationBoundary>
+}
+
+export default CustomHydrationBoundary


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- hydration boundary관련 custom hook으로 분리
- mypage에 적용


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

- 현재 승학님께서 작성하신 코드에서 동작은 확인했으나, detail 페이지로 이동 시 id를 가지고 3개정도 데이터 요청을 따로따로 더하는게 있어서  분리가 불가능합니다. 
- 한번 더 생각해보고 분리된 커스텀 훅 적용해보겠습니다. 
