### PR TITLE
refactor: Provider 정리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next"
 import { SessionProvider } from "next-auth/react"
 import localFont from "next/font/local"
 
+import { createElement } from "react"
+
 import QueryProviders from "@/components/app/provider"
 import GNB from "@/components/public/gnb/GNB"
 import { CountProvider } from "@/provider/CountProvider"
@@ -9,6 +11,35 @@ import { ToastProvider } from "@/provider/ToastProvider"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 import "./globals.css"
+
+export const metadata: Metadata = {
+  title: "같이 달램",
+  description:
+    "유저가 바쁜 일상 속 휴식을 위한 다양한 모임을 탐색하고 참여하며, 직접 모임을 개설하고 리뷰를 생성할 수 있는 서비스입니다.",
+}
+
+const RootLayout = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode
+}>) => {
+  return (
+    <html lang="ko" className={`${pretendard.className} ${tmoneyRoundWind.variable}`}>
+      <body className="bg-gray-100">
+        <QueryProviders>
+          {providers.reduceRight((child, Component) => {
+            return createElement(Component, null, child)
+          }, children)}
+          <DevTools />
+        </QueryProviders>
+      </body>
+    </html>
+  )
+}
+
+export default RootLayout
+
+const providers = [SessionProvider, ToastProvider, CountProvider, GNB] as const
 
 const pretendard = localFont({
   src: [
@@ -55,33 +86,6 @@ const tmoneyRoundWind = localFont({
   variable: "--font-tmoneyRoundWind",
 })
 
-export const metadata: Metadata = {
-  title: "같이 달램",
-  description:
-    "유저가 바쁜 일상 속 휴식을 위한 다양한 모임을 탐색하고 참여하며, 직접 모임을 개설하고 리뷰를 생성할 수 있는 서비스입니다.",
+const DevTools = () => {
+  return process.env.NODE_ENV !== "production" && <ReactQueryDevtools position="bottom" />
 }
-
-const RootLayout = ({
-  children,
-}: Readonly<{
-  children: React.ReactNode
-}>) => {
-  return (
-    <html lang="ko" className={`${pretendard.className} ${tmoneyRoundWind.variable}`}>
-      <body className="bg-gray-100">
-        <SessionProvider>
-          <ToastProvider>
-            <CountProvider>
-              <QueryProviders>
-                <GNB>{children}</GNB>
-                {process.env.NODE_ENV !== "production" && <ReactQueryDevtools position="bottom" />}
-              </QueryProviders>
-            </CountProvider>
-          </ToastProvider>
-        </SessionProvider>
-      </body>
-    </html>
-  )
-}
-
-export default RootLayout


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #43 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Provider 정리
- reduceRight 함수 사용

> 참조 코드
```jsx
const App = () => {
  const providers = [
    [Count1Provider, { initialValue: 10 }],
    [Count2Provider, { initialValue: 10 }],
    [Count3Provider, { initialValue: 10 }],
    [Count4Provider, { initialValue: 10 }],
    [Count5Provider, { initialValue: 10 }],
  ] as const

  return providers.reduceRight((children, [Component, props]) => {
    return createElement(Component, props, children)
  })
}
```
`리액트 훅을 사용한 마이크로 상태관리`

> 기존 코드 

```jsx
const RootLayout = ({
  children,
}: Readonly<{
  children: React.ReactNode
}>) => {
  return (
    <html lang="ko" className={`${pretendard.className} ${tmoneyRoundWind.variable}`}>
      <body className="bg-gray-100">
        <SessionProvider>
          <ToastProvider>
            <CountProvider>
              <QueryProviders>
                <GNB>{children}</GNB>
                {process.env.NODE_ENV !== "production" && <ReactQueryDevtools position="bottom" />}
              </QueryProviders>
            </CountProvider>
          </ToastProvider>
        </SessionProvider>
      </body>
    </html>
  )
}
```

> reduceRight 및 createElement사용

```jsx
const providers = [SessionProvider, ToastProvider, CountProvider, GNB] as const

const RootLayout = ({
  children,
}: Readonly<{
  children: React.ReactNode
}>) => {
  return (
    <html lang="ko" className={`${pretendard.className} ${tmoneyRoundWind.variable}`}>
      <body className="bg-gray-100">
        <QueryProviders>
          {providers.reduceRight((child, Component) => {
            return createElement(Component, null, child)
          }, children)}
          <DevTools />
        </QueryProviders>
      </body>
    </html>
  )
}
```

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>

- ReactQueryDevtools을 사용하려면 QueryProvider내부에 있어야 합니다. 그러나 reduceRight를 쓸 경우 중간에 QueryProvider부분을 전달할 방법이 생각나지 않아 일단 QueryProvider를 바깥으로 빼고 ReactQueryDevtools를 컴포넌트화 한 이후 불러오도록 설정했습니다.
- reduceRight를 굳이 안 쓰고 더 친숙한 reduce를 써도 가능합니다. 다만 함수형 컴포넌트의 curryR기능과 비슷한 함수이면서, 배열 순서를 기존 Provider함수 순서와 일치시키기 위해서 reduceRight를 사용했습니다.
- 컴포넌트든 배열에서도 관리 가능
- createElement 사용 시, 전달할 prop이 없을 경우 {}이 아닌 null을 전달해야 합니다.